### PR TITLE
added export of BATCH constant names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const BATCH = 'BATCHING_REDUCER.BATCH';
+export const BATCH = 'BATCHING_REDUCER.BATCH';
 
 export function batchActions(actions) {
 	return {type: BATCH, payload: actions}


### PR DESCRIPTION
Is it possible to export the `const BATCH` from the source. 

I have a middleware that tag analytics from certain actions, and I need to match the BATCH constant in order to go recursively in the actions array for tagging.

