### PR TITLE
Fix error with React Native's Packager

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src
+.babelrc


### PR DESCRIPTION
Hi there

I'm using React Native (0.46) and got the following error message when I tried to use redux-batched-actions with it:

```
TransformError: [...]/node_modules/redux-batched-actions/lib/index.js: 
Couldn't find preset "es2015" relative to directory "[...]/node_modules/redux-batched-actions"
```

The reason why it happens is React Native's packager tries to transpile packages in node_modules and if one of the package has a `.babelrc` config, it tries to use it.
Here since I don't have the preset used by redux-batched-actions (`"es2015"`) in my main project dependencies, it fails.

One fix is not to ship the `.babelrc` file as part of the npm package so it doesn't confuse RN's packager.

Note that in the future RN will stop transpiling node_modules so this won't be a problem anymore.
See https://github.com/facebook/react-native/issues/10966

Let me know what you think.