### PR TITLE
Add Batch Dispatch Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ const store = createStore(enableBatching(reducer), initialState)
 
 
 // const store = createStore(
-//  enableBatching(reducer),
-//  initialState,
-//  applyMiddleware(batchDispatchMiddleware)
+// 		enableBatching(reducer),
+// 		initialState,
+// 		applyMiddleware(batchDispatchMiddleware)
 // )
 
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ const store = createStore(enableBatching(reducer), initialState)
 
 
 // const store = createStore(
-//   enableBatching(reducer),
-//   initialState,
-//   applyMiddleware(batchDispatchMiddleware)
+//  enableBatching(reducer),
+//  initialState,
+//  applyMiddleware(batchDispatchMiddleware)
 // )
 
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ function reducer(state, action) {
 const store = createStore(enableBatching(reducer), initialState)
 
 // Alternatively, you can add a middleware to dispatch each of the bundled
-actions. This can be used if other middlewares are listening for one of the
-bundled actions to be dispatched
+// actions. This can be used if other middlewares are listening for one of the
+// bundled actions to be dispatched
 
 
-const store = createStore(
-  enableBatching(reducer),
-  initialState,
-  applyMiddleware(batchDispatchMiddleware)
-)
+// const store = createStore(
+//   enableBatching(reducer),
+//   initialState,
+//   applyMiddleware(batchDispatchMiddleware)
+// )
 
 
 store.dispatch(batchActions([doThing(), doOther()]))

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ npm install --save redux-batched-actions
 ## Usage
 
 ```js
-import {createStore} from 'redux';
-import {batchActions, enableBatching} from 'redux-batched-actions';
+import {createStore, applyMiddleware} from 'redux';
+import {batchActions, enableBatching, batchDispatchMiddleware} from 'redux-batched-actions';
 import {createAction} from 'redux-actions';
 
 const doThing = createAction('DO_THING')
@@ -27,11 +27,25 @@ function reducer(state, action) {
 	}
 }
 
+// Handle bundled actions in reducer
 const store = createStore(enableBatching(reducer), initialState)
+
+// Alternatively, you can add a middleware to dispatch each of the bundled
+actions. This can be used if other middlewares are listening for one of the
+bundled actions to be dispatched
+
+
+const store = createStore(
+  enableBatching(reducer),
+  initialState,
+  applyMiddleware(batchDispatchMiddleware)
+)
+
 
 store.dispatch(batchActions([doThing(), doOther()]))
 // OR
 store.dispatch(batchActions([doThing(), doOther()], 'DO_BOTH'))
+
 ```
 
 ## Recipes

--- a/src/index.js
+++ b/src/index.js
@@ -14,20 +14,19 @@ export function enableBatching(reduce) {
 }
 
 export function batchDispatchMiddleware(store) {
-
   function dispatchChildActions(store, action) {
     if(action.meta && action.meta.batch) {
       action.payload.map(function(childAction) {
-        dispatchChildActions(store, childAction);
-      });
+        dispatchChildActions(store, childAction)
+      })
     } else {
-     store.dispatch(action);
+      store.dispatch(action)
     }
   }
   return function(next) {
     return function(action) {
       dispatchChildActions(store, action)
-      next(action);
+      next(action)
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,19 +14,20 @@ export function enableBatching(reduce) {
 }
 
 export function batchDispatchMiddleware(store) {
-  function dispatchChildActions(store, action) {
-    if(action.meta && action.meta.batch) {
-      action.payload.map(function(childAction) {
-        dispatchChildActions(store, childAction)
-      })
-    } else {
-      store.dispatch(action)
-    }
-  }
-  return function(next) {
-    return function(action) {
-      dispatchChildActions(store, action)
-      next(action)
-    }
-  }
+	function dispatchChildActions(store, action) {
+		if(action.meta && action.meta.batch) {
+			action.payload.map(function(childAction) {
+				dispatchChildActions(store, childAction)
+			})
+		} else {
+			store.dispatch(action)
+		}
+	}
+
+	return function(next) {
+		return function(action) {
+			dispatchChildActions(store, action)
+			next(action)
+		}
+	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,22 @@ export function enableBatching(reduce) {
 		return reduce(state, action);
 	}
 }
+
+export function batchDispatchMiddleware(store) {
+
+  function dispatchChildActions(store, action) {
+    if(action.meta && action.meta.batch) {
+      action.payload.map(function(childAction) {
+        dispatchChildActions(store, childAction);
+      });
+    } else {
+     store.dispatch(action);
+    }
+  }
+  return function(next) {
+    return function(action) {
+      dispatchChildActions(store, action)
+      next(action);
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export function enableBatching(reduce) {
 export function batchDispatchMiddleware(store) {
 	function dispatchChildActions(store, action) {
 		if(action.meta && action.meta.batch) {
-			action.payload.map(function(childAction) {
+			action.payload.forEach(function(childAction) {
 				dispatchChildActions(store, childAction)
 			})
 		} else {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -63,28 +63,30 @@ describe('enabling batching', function() {
 
 describe('dispatching middleware', function() {
   const action1 = {type: 'ACTION_1'}
-	const action2 = {type: 'ACTION_2'}
+  const action2 = {type: 'ACTION_2'}
   const store = function () { return { dispatch: sinon.spy() } }
 
   it('dispatches all batched actions', function() {
     const s = store()
     const next = sinon.stub()
     const batchAction = batchActions([action1, action2])
-    batchDispatchMiddleware(s)(next)(batchAction);
-		expect(s.dispatch).to.have.been.calledWithExactly(action1)
-		expect(s.dispatch).to.have.been.calledWithExactly(action2)
+    batchDispatchMiddleware(s)(next)(batchAction)
+
+    expect(s.dispatch).to.have.been.calledWithExactly(action1)
+    expect(s.dispatch).to.have.been.calledWithExactly(action2)
   })
 
-	it('handles nested batched actions', function() {
-		const batchedAction = batchActions([
-			batchActions([action1, action2]),
-			action2
-		])
+  it('handles nested batched actions', function() {
+    const batchedAction = batchActions([
+      batchActions([action1, action2]),
+      action2
+    ])
     const s = store()
     const next = sinon.stub()
-    batchDispatchMiddleware(s)(next)(batchedAction);
-		expect(s.dispatch).to.have.been.calledThrice;
-		expect(s.dispatch).to.have.been.calledWithExactly(action1)
-		expect(s.dispatch).to.have.been.calledWithExactly(action2)
-	})
-});
+    batchDispatchMiddleware(s)(next)(batchedAction)
+
+    expect(s.dispatch).to.have.been.calledThrice
+    expect(s.dispatch).to.have.been.calledWithExactly(action1)
+    expect(s.dispatch).to.have.been.calledWithExactly(action2)
+  })
+})

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -62,31 +62,31 @@ describe('enabling batching', function() {
 })
 
 describe('dispatching middleware', function() {
-  const action1 = {type: 'ACTION_1'}
-  const action2 = {type: 'ACTION_2'}
-  const store = function () { return { dispatch: sinon.spy() } }
+	const action1 = {type: 'ACTION_1'}
+	const action2 = {type: 'ACTION_2'}
+	const store = function () { return { dispatch: sinon.spy() } }
 
-  it('dispatches all batched actions', function() {
-    const s = store()
-    const next = sinon.stub()
-    const batchAction = batchActions([action1, action2])
-    batchDispatchMiddleware(s)(next)(batchAction)
+	it('dispatches all batched actions', function() {
+		const s = store()
+		const next = sinon.stub()
+		const batchAction = batchActions([action1, action2])
+		batchDispatchMiddleware(s)(next)(batchAction)
 
-    expect(s.dispatch).to.have.been.calledWithExactly(action1)
-    expect(s.dispatch).to.have.been.calledWithExactly(action2)
-  })
+		expect(s.dispatch).to.have.been.calledWithExactly(action1)
+		expect(s.dispatch).to.have.been.calledWithExactly(action2)
+	})
 
-  it('handles nested batched actions', function() {
-    const batchedAction = batchActions([
-      batchActions([action1, action2]),
-      action2
-    ])
-    const s = store()
-    const next = sinon.stub()
-    batchDispatchMiddleware(s)(next)(batchedAction)
+	it('handles nested batched actions', function() {
+		const batchedAction = batchActions([
+		  batchActions([action1, action2]),
+		  action2
+		])
+		const s = store()
+		const next = sinon.stub()
+		batchDispatchMiddleware(s)(next)(batchedAction)
 
-    expect(s.dispatch).to.have.been.calledThrice
-    expect(s.dispatch).to.have.been.calledWithExactly(action1)
-    expect(s.dispatch).to.have.been.calledWithExactly(action2)
-  })
+		expect(s.dispatch).to.have.been.calledThrice
+		expect(s.dispatch).to.have.been.calledWithExactly(action1)
+		expect(s.dispatch).to.have.been.calledWithExactly(action2)
+	})
 })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,4 +1,4 @@
-import {batchActions, enableBatching} from '../src';
+import {batchActions, enableBatching, batchDispatchMiddleware} from '../src';
 import sinon from 'sinon';
 import chai, {expect} from 'chai';
 import sinonChai from 'sinon-chai';
@@ -60,3 +60,31 @@ describe('enabling batching', function() {
 	})
 
 })
+
+describe('dispatching middleware', function() {
+  const action1 = {type: 'ACTION_1'}
+	const action2 = {type: 'ACTION_2'}
+  const store = function () { return { dispatch: sinon.spy() } }
+
+  it('dispatches all batched actions', function() {
+    const s = store()
+    const next = sinon.stub()
+    const batchAction = batchActions([action1, action2])
+    batchDispatchMiddleware(s)(next)(batchAction);
+		expect(s.dispatch).to.have.been.calledWithExactly(action1)
+		expect(s.dispatch).to.have.been.calledWithExactly(action2)
+  })
+
+	it('handles nested batched actions', function() {
+		const batchedAction = batchActions([
+			batchActions([action1, action2]),
+			action2
+		])
+    const s = store()
+    const next = sinon.stub()
+    batchDispatchMiddleware(s)(next)(batchedAction);
+		expect(s.dispatch).to.have.been.calledThrice;
+		expect(s.dispatch).to.have.been.calledWithExactly(action1)
+		expect(s.dispatch).to.have.been.calledWithExactly(action2)
+	})
+});


### PR DESCRIPTION
**Use Case** 

Dispatch a batched action, that includes at least one action that triggers an external side effect in another middleware

** Solution ** 

Add middleware that will intercept a batched action, and dispatch all of the bulk actions individually. This allows a single user interaction to kick off a batch action, while still decoupling other middleware from the concept of batch actions.