### PR TITLE
add meta to BatchAction typescript interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,9 @@ export declare const BATCH: BatchActionType;
 export interface BatchAction {
   type: BatchActionType;
   payload: Redux.Action[];
+  meta: {
+    batch: true
+  }
 }
 
 export declare function batchActions(actions: Redux.Action[], type?: string): BatchAction;


### PR DESCRIPTION
currently, the following does not typecheck b/c `meta.batch` is not part of the type definition:

```ts
(action: Action | BatchAction) => action.meta.batch
```

This prevents writing a function like `isBatchedAction` in typescript.