### PR TITLE
Allow AnyAction in batchActions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ export interface BatchAction {
   }
 }
 
-export declare function batchActions(actions: Redux.Action[], type?: string): BatchAction;
+export declare function batchActions(actions: Redux.AnyAction[], type?: string): BatchAction;
 
 export declare function enableBatching<S>(reduce: Redux.Reducer<S>): Redux.Reducer<S>;
 


### PR DESCRIPTION
Currently it seems impossible to add extra data to an action while using TypeScript, because batchActions takes `Action`s, not `AnyAction`s.