### PR TITLE
added default combined type for batched actions in order to get reada…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 export const BATCH = 'BATCHING_REDUCER.BATCH';
 
-export function batchActions(actions, type = BATCH) {
+function combineBatchedActionTypes(actions) {
+	return `${BATCH}: ${actions
+		.map(({ type }) => type)
+		.join(" & ")}`
+}
+
+
+export function batchActions(actions, type = combineBatchedActionTypes(actions)) {
 	return {type, meta: { batch: true }, payload: actions}
 }
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -10,7 +10,7 @@ describe('batching actions', function() {
 		const action1 = {type: 'ACTION_1'}
 		const action2 = {type: 'ACTION_2'}
 		expect(batchActions([action1, action2])).to.deep.equal({
-			type: 'BATCHING_REDUCER.BATCH',
+			type: 'BATCHING_REDUCER.BATCH: ACTION_1 & ACTION_2',
 			meta: { batch: true },
 			payload: [action1, action2]
 		})


### PR DESCRIPTION
Added default combined type for batched actions in order to get readbility in redux-devtools and loggers.
I use this feature and think that the ability to see in logger/redux-devtools which actions exactly were batched could be useful.