### PR TITLE
Truly batch actions with batch middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In this example, the subscribers would be notified twice: once when the state is
 ### Middleware integration
 
 You can add a middleware to dispatch each of the bundled actions. This can be used if other middlewares are listening for one of the bundled actions to be dispatched.  
-**Note:** Only the middlewares *before* the batch middleware will recieve each of the bundled actions.
+**Note:** Only the middlewares *before* the batch middleware will receive each of the bundled actions. *All* middlewares will receive the batch action.
 
 ```js
 const store = createStore(
@@ -78,7 +78,7 @@ const store = createStore(
 )
 ```
 
-`enableBatching` should still be used on the reducer as the reducer will only recieve the batched action, not each bundled action.
+`enableBatching` should still be used on the reducer as the reducer will only receive the batched action, not each bundled action.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -67,17 +67,18 @@ In this example, the subscribers would be notified twice: once when the state is
 
 ### Middleware integration
 
-You can add a middleware to dispatch each of the bundled actions. This can be used if other middlewares are listening for one of the bundled actions to be dispatched.
+You can add a middleware to dispatch each of the bundled actions. This can be used if other middlewares are listening for one of the bundled actions to be dispatched.  
+**Note:** Only the middlewares *before* the batch middleware will recieve each of the bundled actions.
 
 ```js
 const store = createStore(
-		reducer,
+		enableBatching(reducer),
 		initialState,
-		applyMiddleware(batchDispatchMiddleware)
+		applyMiddleware(middlewareThatNeedsEachBundledAction, batchDispatchMiddleware, middlewareThatDoesNotNeedEachBundledAction)
 )
 ```
 
-Note that batchDispatchMiddleware and enableBatching should not be used together as batchDispatchMiddleware calls next on the action it receives, whilst also dispatching each of the bundled actions.
+`enableBatching` should still be used on the reducer as the reducer will only recieve the batched action, not each bundled action.
 
 ## Thanks
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "js-to-mjs": "^0.2.0",
     "mocha": "^7.1.1",
     "sinon": "^9.0.1",
-    "sinon-chai": "^3.5.0"
+    "sinon-chai": "^3.5.0",
+    "redux": ">=1.0.0"
   },
   "peerDependencies": {
     "redux": ">=1.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export function batchDispatchMiddleware(store) {
 				dispatchChildActions(store, childAction)
 			})
 		} else {
-			store.dispatch(action)
+			store.dispatch({ ...action, meta: { ...action.meta, unwrappedFromBatch: true }})
 		}
 	}
 
@@ -29,7 +29,9 @@ export function batchDispatchMiddleware(store) {
 			if (action && action.meta && action.meta.batch) {
 				dispatchChildActions(store, action)
 			}
-			return next(action)
+			if (!(action && action.meta && action.meta.unwrappedFromBatch)) {
+				return next(action)
+			}
 		}
 	}
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,14 +1,15 @@
-import {batchActions, enableBatching, batchDispatchMiddleware} from '../src';
+import { batchActions, enableBatching, batchDispatchMiddleware } from '../src';
 import sinon from 'sinon';
-import chai, {expect} from 'chai';
+import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
+import { createStore, applyMiddleware, createMiddlewareSpy, createReducerSpy } from './redux-spy';
 chai.use(sinonChai);
 
-describe('batching actions', function() {
+describe('batching actions', function () {
 
-	it('wraps actions in a batch action', function() {
-		const action1 = {type: 'ACTION_1'}
-		const action2 = {type: 'ACTION_2'}
+	it('wraps actions in a batch action', function () {
+		const action1 = { type: 'ACTION_1' }
+		const action2 = { type: 'ACTION_2' }
 		expect(batchActions([action1, action2])).to.deep.equal({
 			type: 'BATCHING_REDUCER.BATCH',
 			meta: { batch: true },
@@ -16,9 +17,9 @@ describe('batching actions', function() {
 		})
 	})
 
-	it('uses a custom type, if provided', function() {
-		const action1 = {type: 'ACTION_1'}
-		const action2 = {type: 'ACTION_2'}
+	it('uses a custom type, if provided', function () {
+		const action1 = { type: 'ACTION_1' }
+		const action2 = { type: 'ACTION_2' }
 		expect(batchActions([action1, action2], 'CUSTOM_ACTION')).to.deep.equal({
 			type: 'CUSTOM_ACTION',
 			meta: { batch: true },
@@ -28,27 +29,27 @@ describe('batching actions', function() {
 
 })
 
-describe('enabling batching', function() {
-	const action1 = {type: 'ACTION_1'}
-	const action2 = {type: 'ACTION_2'}
+describe('enabling batching', function () {
+	const action1 = { type: 'ACTION_1' }
+	const action2 = { type: 'ACTION_2' }
 	const reducer = sinon.stub()
 	reducer.withArgs(0, action1).returns(1)
 	reducer.withArgs(1, action2).returns(2)
 	reducer.withArgs(2, action2).returns(5)
 	const batchedReducer = enableBatching(reducer)
 
-	it('passes actions through that are not batched', function() {
+	it('passes actions through that are not batched', function () {
 		expect(batchedReducer(0, action1)).to.equal(1)
 		expect(reducer).to.have.been.calledWithExactly(0, action1)
 	})
 
-	it('passes actions through that are batched', function() {
+	it('passes actions through that are batched', function () {
 		expect(batchedReducer(0, batchActions([action1, action2]))).to.equal(2)
 		expect(reducer).to.have.been.calledWithExactly(0, action1)
 		expect(reducer).to.have.been.calledWithExactly(1, action2)
 	})
 
-	it('handles nested batched actions', function() {
+	it('handles nested batched actions', function () {
 		const batchedAction = batchActions([
 			batchActions([action1, action2]),
 			action2
@@ -61,51 +62,83 @@ describe('enabling batching', function() {
 
 })
 
-describe('dispatching middleware', function() {
-	const action1 = {type: 'ACTION_1'}
-	const action2 = {type: 'ACTION_2'}
-	const store = function () { return { dispatch: sinon.spy() } }
+describe('dispatching middleware', function () {
+	const action1 = { type: 'ACTION_1' }
+	const action2 = { type: 'ACTION_2' }
 
-	it('dispatches all batched actions', function() {
-		const s = store()
-		const next = sinon.stub()
+	const initialState = null;
+	const doNothingReducer = (state, action) => state
+
+	it('dispatches batched actions', function () {
+		const store = createStore(doNothingReducer, initialState, applyMiddleware(batchDispatchMiddleware))
 		const batchAction = batchActions([action1, action2])
-		batchDispatchMiddleware(s)(next)(batchAction)
 
-		expect(s.dispatch).to.have.been.calledWithExactly(action1)
-		expect(s.dispatch).to.have.been.calledWithExactly(action2)
+		store.dispatch(batchAction)
+
+		expect(store.dispatch).to.have.callCount(3)
+		expect(store.dispatch).to.have.been.calledWithExactly(batchAction)
+		expect(store.dispatch).to.have.been.calledWithMatch(sinon.match(action1))
+		expect(store.dispatch).to.have.been.calledWithMatch(sinon.match(action2))
 	})
 
-	it('calls next only once, on the batchedAction', function() {
-		const s = store()
-		const next = sinon.spy()
-		const batchAction = batchActions([action1, action2])
-		batchDispatchMiddleware(s)(next)(batchAction)
+	it('handles nested batched actions', function () {
+		const store = createStore(doNothingReducer, initialState, applyMiddleware(batchDispatchMiddleware))
 
-		expect(next).to.have.been.calledWithExactly(batchAction)
-		expect(next).to.have.callCount(1)
-	})
-
-	it('handles nested batched actions', function() {
 		const batchedAction = batchActions([
-		  batchActions([action1, action2]),
-		  action2
+			batchActions([action1, action2]),
+			action2
 		])
-		const s = store()
-		const next = sinon.stub()
-		batchDispatchMiddleware(s)(next)(batchedAction)
 
-		expect(s.dispatch).to.have.been.calledThrice
-		expect(s.dispatch).to.have.been.calledWithExactly(action1)
-		expect(s.dispatch).to.have.been.calledWithExactly(action2)
+		store.dispatch(batchedAction)
+
+		expect(store.dispatch).to.have.callCount(4)
+		expect(store.dispatch).to.have.been.calledWithExactly(batchedAction)
+		expect(store.dispatch).to.have.been.calledWithMatch(sinon.match(action1))
+		expect(store.dispatch).to.have.been.calledWithMatch(sinon.match(action2))
 	})
 
-	it('calls next but not dispatch for non-batched actions', function() {
-		const s = store()
-		const next = sinon.spy()
-		batchDispatchMiddleware(s)(next)(action1)
+	it('passes through non-batched actions without extra dispatches', function () {
+		const store = createStore(doNothingReducer, initialState, applyMiddleware(batchDispatchMiddleware))
 
-		expect(next).to.have.been.calledWithExactly(action1)
-		expect(s.dispatch).to.not.have.been.called
+		store.dispatch(action1)
+
+		expect(store.dispatch).to.have.callCount(1)
+		expect(store.dispatch).to.have.been.calledWithExactly(action1)
+	})
+
+	it('sends every batched action to previous middlewares', function () {
+		const { middleware, middlewareOnRecieveActionSpy } = createMiddlewareSpy()
+		const store = createStore(doNothingReducer, initialState, applyMiddleware(middleware, batchDispatchMiddleware))
+		const batchAction = batchActions([action1, action2])
+
+		store.dispatch(batchAction)
+
+		expect(middlewareOnRecieveActionSpy).to.have.callCount(3)
+		expect(middlewareOnRecieveActionSpy).to.have.been.calledWithExactly(batchAction)
+		expect(middlewareOnRecieveActionSpy).to.have.been.calledWithMatch(sinon.match(action1))
+		expect(middlewareOnRecieveActionSpy).to.have.been.calledWithMatch(sinon.match(action2))
+	})
+
+	it('sends only the batched action to the reducer', function () {
+		const { reducer, reducerOnRecieveActionSpy } = createReducerSpy()
+		const store = createStore(reducer, initialState, applyMiddleware(batchDispatchMiddleware))
+		const batchAction = batchActions([action1, action2])
+
+		store.dispatch(batchAction)
+
+		expect(reducerOnRecieveActionSpy).to.have.been.calledWithExactly(batchAction)
+		expect(reducerOnRecieveActionSpy).to.have.callCount(1)
+	})
+
+	it('does not send any batched actions to subsequent middlewares', function () {
+		const { middleware, middlewareOnRecieveActionSpy } = createMiddlewareSpy()
+
+		const store = createStore(doNothingReducer, initialState, applyMiddleware(batchDispatchMiddleware, middleware))
+		const batchAction = batchActions([action1, action2])
+
+		store.dispatch(batchAction)
+
+		expect(middlewareOnRecieveActionSpy).to.have.callCount(1)
+		expect(middlewareOnRecieveActionSpy).to.have.been.calledWithExactly(batchAction)
 	})
 })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -120,7 +120,7 @@ describe('batch middleware applied in a real redux store', function () {
 
 	const initialState = null;
 	const doNothingReducer = (state, action) => state
-
+	
 	it('sends only the batched action to the reducer', function () {
 		const { reducer, reducerOnRecieveActionSpy } = createReducerSpy()
 		const store = createStore(reducer, initialState, applyMiddleware(batchDispatchMiddleware))
@@ -179,5 +179,34 @@ describe('batch middleware applied in a real redux store', function () {
 
 		expect(middlewareOnRecieveActionSpy).to.have.been.calledWithExactly(batchAction)
 		expect(middlewareOnRecieveActionSpy).to.have.been.calledOnce
+	})
+})
+
+describe('full middleware usage with enableBatching', function () {
+	const action1 = { type: 'ACTION_1' }
+	const action2 = { type: 'ACTION_2' }
+
+	let reduceAction, store;
+	beforeEach(function() {
+		const { reducer, reducerOnRecieveActionSpy } = createReducerSpy()
+		reduceAction = reducerOnRecieveActionSpy
+		store = createStore(enableBatching(reducer), null, applyMiddleware(batchDispatchMiddleware))
+	})
+
+	it('reduces each bundled action', function () {
+		const batchedAction = batchActions([action1, action2])
+
+		store.dispatch(batchedAction)
+
+		expect(reduceAction).to.have.been.calledWithExactly(action1)
+		expect(reduceAction).to.have.been.calledWithExactly(action2)
+		expect(reduceAction).to.have.been.calledTwice
+	})
+
+	it('passes through non-batched actions', function () {
+		store.dispatch(action1)
+
+		expect(reduceAction).to.have.been.calledWithExactly(action1)
+		expect(reduceAction).to.have.been.calledOnce
 	})
 })

--- a/test/redux-spy.js
+++ b/test/redux-spy.js
@@ -1,43 +1,6 @@
 import sinon from 'sinon';
 
-const defaultEnhancer = (storeCreator) => storeCreator
-export const createStore = (reducer, initialState = undefined, enhancer = defaultEnhancer) => {
-    const enhancedCreateStore = enhancer(baseCreateStore)
-    return enhancedCreateStore(reducer, initialState);
-}
-
-const baseCreateStore = (reducer, initialState = undefined) => {
-    let state = initialState;
-    const updateStateWithAction = function (action) {
-        state = reducer(state, action)
-    }
-
-    const store = {
-        getState: () => state,
-        dispatch: sinon.spy(updateStateWithAction)
-    }
-
-    return store;
-}
-
-export const applyMiddleware = (...middlewares) => {
-    const storeEnhancer = (storeCreator) => {
-        const enhancedStoreCreator = (reducer, initialState = undefined) => {
-            const store = storeCreator(reducer, initialState);
-            const oldDispatch = store.dispatch;
-            const passActionThroughMiddlewaresToDispatch = middlewares.reverse().reduce(
-                (next, middleware) => middleware(store)(next),
-                oldDispatch
-            );
-            store.dispatch = sinon.spy(passActionThroughMiddlewaresToDispatch)
-            return store;
-        }
-        return enhancedStoreCreator;
-    }
-    return storeEnhancer;
-}
-
-export const createMiddlewareSpy = () => {
+export function createMiddlewareSpy() {
     const middlewareOnRecieveActionSpy = sinon.spy()
     const middleware = store => next => action => {
         middlewareOnRecieveActionSpy(action)
@@ -46,10 +9,16 @@ export const createMiddlewareSpy = () => {
     return { middleware, middlewareOnRecieveActionSpy }
 }
 
-export const createReducerSpy = () => {
+function isInternalReduxAction(action) {
+    return action.type.startsWith('@@');
+}
+
+export function createReducerSpy() {
     const reducerOnRecieveActionSpy = sinon.spy()
     const reducer = (state, action) => {
-        reducerOnRecieveActionSpy(action)
+        if (!isInternalReduxAction(action)) {
+            reducerOnRecieveActionSpy(action)
+        }
         return state
     }
     return { reducer, reducerOnRecieveActionSpy }

--- a/test/redux-spy.js
+++ b/test/redux-spy.js
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+
+const defaultEnhancer = (storeCreator) => storeCreator
+export const createStore = (reducer, initialState = undefined, enhancer = defaultEnhancer) => {
+    const enhancedCreateStore = enhancer(baseCreateStore)
+    return enhancedCreateStore(reducer, initialState);
+}
+
+const baseCreateStore = (reducer, initialState = undefined) => {
+    let state = initialState;
+    const updateStateWithAction = function (action) {
+        state = reducer(state, action)
+    }
+
+    const store = {
+        getState: () => state,
+        dispatch: sinon.spy(updateStateWithAction)
+    }
+
+    return store;
+}
+
+export const applyMiddleware = (...middlewares) => {
+    const storeEnhancer = (storeCreator) => {
+        const enhancedStoreCreator = (reducer, initialState = undefined) => {
+            const store = storeCreator(reducer, initialState);
+            const oldDispatch = store.dispatch;
+            const passActionThroughMiddlewaresToDispatch = middlewares.reverse().reduce(
+                (next, middleware) => middleware(store)(next),
+                oldDispatch
+            );
+            store.dispatch = sinon.spy(passActionThroughMiddlewaresToDispatch)
+            return store;
+        }
+        return enhancedStoreCreator;
+    }
+    return storeEnhancer;
+}
+
+export const createMiddlewareSpy = () => {
+    const middlewareOnRecieveActionSpy = sinon.spy()
+    const middleware = store => next => action => {
+        middlewareOnRecieveActionSpy(action)
+        next(action)
+    }
+    return { middleware, middlewareOnRecieveActionSpy }
+}
+
+export const createReducerSpy = () => {
+    const reducerOnRecieveActionSpy = sinon.spy()
+    const reducer = (state, action) => {
+        reducerOnRecieveActionSpy(action)
+        return state
+    }
+    return { reducer, reducerOnRecieveActionSpy }
+}


### PR DESCRIPTION
Fixes #23 
Also, check out the discussion around this on the original batch middleware PR: #18 

## Problem:
Calling `store.dispatch` sends the action through all the middlewares again _and updates the store_.
So because the batch middleware dispatches each bundled action, the reducer receives each one and the state updates each time.
**When using batch middleware, the store updates n times for a batch action with n actions, instead of 1 time.**

## Solution:
Whenever the batch middleware dispatches one of the bundled actions in a batch action, it marks it as `unwrappedFromBatch`. When this action comes back through the middlewares, the batch middleware looks for the `unwrappedFromBatch` flag and, if present, does nothing (does not call `next`, so it does not reach later middlewares _nor the reducer/store to update_).

I have used this approach with redux-saga successfully.

## Tests Update
I added "integration tests" to test the behavior of the middleware in a real redux store.

At first glance, I thought the existing code would not send each bundled action to the reducer, because of this test:

```js
	it('calls next only once, on the batchedAction', function() {
		const s = store()
		const next = sinon.spy()
		const batchAction = batchActions([action1, action2])
		batchDispatchMiddleware(s)(next)(batchAction)

		expect(next).to.have.been.calledWithExactly(batchAction)
		expect(next).to.have.callCount(1)
	})
```

However, this test is for the middleware _in isolation_, not in a redux store. So I added tests for the middleware behavior in a real redux store.