### PR TITLE
work with Redux >= 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
   "name": "redux-batched-actions",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "redux higher order reducer + action creator to reduce actions under a single subscriber notification",
   "main": "lib/index.js",
   "unpkg": "dist/index.js",
   "module": "es/index.mjs",
   "types": "lib/index.d.ts",
   "scripts": {
-    "test": "export BABEL_ENV=cjs && node_modules/.bin/mocha --require @babel/register",
-    "clean": "rm -rf lib es dist",
-    "copy:ts": "cp src/index.d.ts lib/index.d.ts",
+    "test": "npx -y cross-env BABEL_ENV=cjs npx -y mocha --require @babel/register",
+    "clean": "npx -y shx rm -rf lib es dist",
+    "copy:ts": "npx -y shx cp src/index.d.ts lib/index.d.ts",
     "build:js": "babel src",
     "build:cjs": "npm run build:js -- --env-name cjs --out-dir lib/",
-    "build:mjs": "npm run build:js -- --env-name mjs --out-dir es/; j2m es/*",
+    "build:mjs": "npm run build:js -- --env-name mjs --out-dir es/ && npx -y js2mjs es/",
     "build:umd": "npm run build:js -- --env-name dist --out-dir dist/",
-    "build": "npm run clean; npm run build:umd && npm run build:cjs && npm run build:mjs && npm run copy:ts",
+    "build": "npm run clean && npm run build:umd && npm run build:cjs && npm run build:mjs && npm run copy:ts",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "repository": {
@@ -38,17 +38,16 @@
   },
   "homepage": "https://github.com/tshelburne/redux-batched-actions",
   "devDependencies": {
-    "@babel/cli": "^7.8.4",
-    "@babel/core": "^7.9.0",
-    "@babel/preset-env": "^7.9.0",
-    "@babel/register": "^7.9.0",
-    "chai": "^4.2.0",
-    "js-to-mjs": "^0.2.0",
-    "mocha": "^7.1.1",
-    "sinon": "^9.0.1",
-    "sinon-chai": "^3.5.0"
+    "@babel/cli": "^7.23.4",
+    "@babel/core": "^7.23.6",
+    "@babel/preset-env": "^7.23.6",
+    "@babel/register": "^7.22.15",
+    "chai": "^4.3.10",
+    "mocha": "^10.2.0",
+    "sinon": "^17.0.1",
+    "sinon-chai": "^3.7.0"
   },
   "peerDependencies": {
-    "redux": ">=1.0.0"
+    "redux": ">=5.0.0"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,15 +3,15 @@ import * as Redux from 'redux';
 export declare type BatchActionType = 'BATCHING_REDUCER.BATCH';
 export declare const BATCH: BatchActionType;
 
-export interface BatchAction {
+export interface BatchAction extends Redux.UnknownAction {
   type: BatchActionType;
-  payload: Redux.Action[];
+  payload: Redux.UnknownAction[];
   meta: {
     batch: true
   }
 }
 
-export declare function batchActions(actions: Redux.AnyAction[], type?: string): BatchAction;
+export declare function batchActions(actions: Redux.UnknownAction[], type?: string): BatchAction;
 
 export declare function enableBatching<S>(reduce: Redux.Reducer<S>): Redux.Reducer<S>;
 


### PR DESCRIPTION
- fixes all batchAction calls emitting TS errors about BatchAction not being compatible with UnknownAction
- break compatibility with Redux < 5.0.0, therefore including a major version bump
- update all dependencies to latest, except for chai@5.x, as sinon-chai needs an update to install correctly with chai@5
- remove unnecessary dev dependencies that can be run via npx
- test, clean, copy:ts, build:mjs, build commands all updated to work cross-platform using npx shx and npx cross-env
- all tests run complete